### PR TITLE
Lower forecast length in example forecast

### DIFF
--- a/examples/fetch_forecast.py
+++ b/examples/fetch_forecast.py
@@ -11,7 +11,8 @@ if __name__=='__main__':
     atlantic_wave_model = surfpy.wavemodel.atlantic_gfs_wave_model()
 
     print('Fetching GFS Wave Data')
-    wave_grib_data = atlantic_wave_model.fetch_grib_datas(0, 384)
+    num_hours_to_forecast = 24 # One day forecast. Change to 384 to get a 16 day forecast
+    wave_grib_data = atlantic_wave_model.fetch_grib_datas(0, num_hours_to_forecast)
     raw_wave_data = atlantic_wave_model.parse_grib_datas(ri_wave_location, wave_grib_data)
     if raw_wave_data:
         data = atlantic_wave_model.to_buoy_data(raw_wave_data)


### PR DESCRIPTION
When I first ran the forecast, it took so long that I thought it was broken. Figured that for example purposes it would be better to have a shorter forecast and let the developer adjust it up if needed.