### PR TITLE
Update Retry class

### DIFF
--- a/surfpy/tools.py
+++ b/surfpy/tools.py
@@ -6,7 +6,7 @@ import time
 try:
     import requests
     from requests.adapters import HTTPAdapter
-    from requests.packages.urllib3.util.retry import Retry
+    from urllib3 import Retry
 except:
     pass
 
@@ -254,7 +254,7 @@ def retry_session(retries=1):
     retries = Retry(total=retries,
                 backoff_factor=0.1,
                 status_forcelist=[500, 502, 503, 504],
-                method_whitelist=frozenset(['GET', 'POST']))
+                allowed_methods=frozenset(['GET', 'POST']))
 
     session.mount('https://', HTTPAdapter(max_retries=retries))
     session.mount('http://', HTTPAdapter(max_retries=retries))

--- a/surfpy/tools.py
+++ b/surfpy/tools.py
@@ -6,7 +6,7 @@ import time
 try:
     import requests
     from requests.adapters import HTTPAdapter
-    from urllib3 import Retry
+    from urllib3.util import Retry
 except:
     pass
 


### PR DESCRIPTION
Changes:
- Fix for [deprecated `method_whitelist` parameter](https://urllib3.readthedocs.io/en/1.26.8/reference/urllib3.util.html) https://github.com/mpiannucci/surfpy/issues/22
- Updated the `Retry` import to use `urllib3` since the `Retry` class is no longer exposed by the `requests` library.