### PR TITLE
fix: roll over year on datetime

### DIFF
--- a/surfpy/buoystation.py
+++ b/surfpy/buoystation.py
@@ -308,14 +308,16 @@ class BuoyStation(BaseStation):
             day = int(raw_date_components[0].strip())
             hour = int(raw_date_components[1].strip())
             month = model_run_date.month
+            year = model_run_date.year
             if day < model_run_date.day:
                 if model_run_date.month == 12:
                     month = 1
+                    year += 1
                 else: 
                     month += 1
             
             datapoint = BuoyData(unit=units.Units.metric)
-            datapoint.date = pytz.utc.localize(datetime(model_run_date.year, month, day, hour))
+            datapoint.date = pytz.utc.localize(datetime(year, month, day, hour))
 
             summary = columns[2].split()
             if len(summary) < 2:


### PR DESCRIPTION
# Fix year handling in wave forecast bulletin parser

Fixed an issue in the wave forecast bulletin parser where forecasts spanning across a new year were incorrectly dated. Before, when a forecast crossed from December into January, the January dates were assigned to the same year instead of incrementing to the next year which caused some issues when charting and reading the data

ex: forecast dates were incorrectly showing:
- Start: 2024-12-23
- End: 2024-01-08

The fix properly handles the year transition, ensuring January dates are correctly assigned to the next year

## Changes
- Added year tracking in the date parsing logic
- Updated the month rollover handling to increment the year when transitioning from December to January