### PR TITLE
Fix regex character class escape

### DIFF
--- a/surfpy/buoystation.py
+++ b/surfpy/buoystation.py
@@ -91,7 +91,7 @@ class BuoyStation(BaseStation):
             raw_value = comps[1].strip().split()
 
             if variable == 'wind':
-                data.wind_direction = parse_float(re.findall("\d+", raw_value[1])[0])
+                data.wind_direction = parse_float(re.findall("\\d+", raw_value[1])[0])
                 data.wind_compass_direction = units.degree_to_direction(data.wind_direction)
                 data.wind_speed = units.convert(parse_float(raw_value[2]), units.Measurement.speed, units.Units.knots, units.Units.english)
             elif variable == 'gust':


### PR DESCRIPTION
Escape back-slash in regex for all digits. Resolves `SyntaxWarning` in newer versions of Python.

```
Python 3.12.9 (main, Feb  5 2025, 08:49:00) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> print("\d")
<stdin>:1: SyntaxWarning: invalid escape sequence '\d'
\d
>>> print("\\d")
\d
```